### PR TITLE
fix homepage scrollbar issue

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,7 +9,7 @@
 </svelte:head>
 
 <div class="flex flex-col">
-    <div class="min-h-screen flex flex-col items-center justify-center">
+    <div class="min-h-screen -m-10 flex flex-col items-center justify-center">
         <div class="flex flex-col items-center w-[40rem] gap-12 text-center">
             <h1 class="font-sans text-5xl text-slate-50 font-bold leading-normal flex flex-col">
                 <span>Say Goodbye to Uninspired</span>


### PR DESCRIPTION
The layout adds 10 units of padding (5 top and 5 bottom), this removes the padding for the homepage to keep it centred and take up the full height.